### PR TITLE
Add prepared queries support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+
+## 1.1.0
  - 2016-08-09 Stefan Merettig <stefan-merettig@nuriaproject.org> Add .respond_to? and .respond_to_missing? to Diplomat::RestClient
  - 2016-09-21 Dana Pieluszczak <dana@greenhouse.io> Add recurse option to Kv#delete
  - 2016-10-24 Ryan Duffield <rduffield@pagerduty.com> Add tag option to Health#service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
  - 2016-08-09 Stefan Merettig <stefan-merettig@nuriaproject.org> Add .respond_to? and .respond_to_missing? to Diplomat::RestClient
  - 2016-09-21 Dana Pieluszczak <dana@greenhouse.io> Add recurse option to Kv#delete
+ - 2016-10-24 Ryan Duffield <rduffield@pagerduty.com> Add tag option to Health#service
 
 ## 0.19.0, 1.0.0
  - 2016-08-02 John Hamelink <john@johnhamelink.com> Improve ACL and Event endpoints by uniformly raising an error for statuscodes which aren't 200.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - 2016-08-09 Stefan Merettig <stefan-merettig@nuriaproject.org> Add .respond_to? and .respond_to_missing? to Diplomat::RestClient
  - 2016-09-21 Dana Pieluszczak <dana@greenhouse.io> Add recurse option to Kv#delete
  - 2016-10-24 Ryan Duffield <rduffield@pagerduty.com> Add tag option to Health#service
+ - 2016-11-05 Trevor Wood <trevor.g.wood@gmail.com> Diplomat::Node.get returns a hash instead of an OpenStruct
 
 ## 0.19.0, 1.0.0
  - 2016-08-02 John Hamelink <john@johnhamelink.com> Improve ACL and Event endpoints by uniformly raising an error for statuscodes which aren't 200.

--- a/lib/diplomat.rb
+++ b/lib/diplomat.rb
@@ -25,7 +25,7 @@ module Diplomat
 
   require_libs "configuration", "rest_client", "api_options", "kv", "datacenter",
     "service", "members", "node", "nodes", "check", "health", "session", "lock",
-    "error", "event", "acl", "maintenance"
+    "error", "event", "acl", "prepared_query", "maintenance"
   self.configuration ||= Diplomat::Configuration.new
 
   class << self

--- a/lib/diplomat/error.rb
+++ b/lib/diplomat/error.rb
@@ -4,6 +4,8 @@ module Diplomat
   class KeyAlreadyExists < StandardError; end
   class AclNotFound < StandardError; end
   class AclAlreadyExists < StandardError; end
+  class PreparedQueryNotFound < StandardError; end
+  class PreparedQueryAlreadyExists < StandardError; end
   class EventNotFound < StandardError; end
   class EventAlreadyExists < StandardError; end
   class UnknownStatus < StandardError; end

--- a/lib/diplomat/health.rb
+++ b/lib/diplomat/health.rb
@@ -46,11 +46,13 @@ module Diplomat
     # @param s [String] the service
     # @param options [Hash] :dc string for dc specific query
     # @param options [Hash] :state string for specific service state
+    # @param options [Hash] :tag string for specific tag
     # @return [OpenStruct] all data associated with the node
     def service s, options=nil
       url = ["/v1/health/service/#{s}"]
       url << use_named_parameter('dc', options[:dc]) if options and options[:dc]
       url << options[:state] if options and options[:state]
+      url << use_named_parameter('tag', options[:tag]) if options and options[:tag]
 
       # If the request fails, it's probably due to a bad path
       # so return a PathNotFound error. 

--- a/lib/diplomat/kv.rb
+++ b/lib/diplomat/kv.rb
@@ -99,7 +99,7 @@ module Diplomat
         req.url concat_url url
         req.options.timeout = 86400
       end
-      parse_body
+      @raw = parse_body
       return_value(return_nil_values, transformation)
     end
 

--- a/lib/diplomat/node.rb
+++ b/lib/diplomat/node.rb
@@ -25,7 +25,7 @@ module Diplomat
       rescue Faraday::ClientError
         raise Diplomat::PathNotFound
       end
-      return JSON.parse(ret.body)
+      return OpenStruct.new JSON.parse(ret.body)
     end
 
     # Get all the nodes

--- a/lib/diplomat/prepared_query.rb
+++ b/lib/diplomat/prepared_query.rb
@@ -1,0 +1,102 @@
+require 'base64'
+require 'faraday'
+
+module Diplomat
+  class PreparedQuery < Diplomat::RestClient
+
+    include ApiOptions
+
+    @access_methods = [ :list, :info, :create, :destroy, :update ]
+    attr_reader :name, :pquery
+
+    # Get Prepared Query info by name
+    # @param name [String] Name of the Query to get
+    # @return [Hash]
+    def info name, not_found=:reject, found=:return
+      @name = name
+
+      # As long as creating a query is not doable by specifying an ID,
+      # but that one is used is subsequent calls (update, delete), we
+      # rely on list to search by Name
+      result = self.list.select { |pquery| pquery['Name'] == @name }
+
+      if result.nil? || result.empty?
+        case not_found
+          when :reject
+            raise Diplomat::PreparedQueryNotFound, name
+          when :return
+            return nil
+        end
+      else
+        case found
+          when :reject
+            raise Diplomat::PreparedQueryAlreadyExists, name
+          when :return
+            return result.first
+        end
+      end
+    end
+
+    # List all Prepared Queries
+    # @return [List] list of [Hash] of Prepared Queries
+    def list
+      url = ["/v1/query"]
+      url += check_acl_token
+      @raw = @conn_no_err.get concat_url url
+      return parse_body
+    end
+
+    # Update a Prepared Query definition, create if not present
+    # @param pquery [Hash] Prepared Query definition
+    # @return [Hash] The result Prepared Query
+    def update name, pquery
+      @name = name
+
+      old_query = info(name)
+      id = old_query['ID']
+
+      # ID is added to match the API spec
+      pquery['ID'] = id
+
+      @raw = @conn.put do |req|
+        url = ["/v1/query/#{id}"]
+        url += check_acl_token
+        req.url concat_url url
+        req.body = pquery.to_json
+      end
+      return @raw.status == 200
+    end
+
+    # Create a Prepared Query
+    # @param pquery [Hash] Prepared Query definition
+    # @return [Hash] The result Prepared Query
+    def create pquery
+      @raw = @conn.post do |req|
+        url = ["/v1/query"]
+        url += check_acl_token
+        req.url concat_url url
+        req.body = pquery.to_json
+      end
+      doc = parse_body
+      @id = doc['ID']
+      return doc
+    end
+
+    # Destroy a Prepared Query by its id
+    # @param Name [String] the Prepared Query Name
+    # @return [Bool]
+    def destroy name
+      @name = name
+
+      old_query = info(name)
+      id = old_query['ID']
+
+      @raw = @conn.delete do |req|
+        url = ["/v1/query/#{@id}"]
+        url += check_acl_token
+        req.url concat_url url
+      end
+      return @raw.status == 200
+    end
+  end
+end

--- a/lib/diplomat/version.rb
+++ b/lib/diplomat/version.rb
@@ -1,3 +1,3 @@
 module Diplomat
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/spec/health_spec.rb
+++ b/spec/health_spec.rb
@@ -220,6 +220,55 @@ EOF
       expect(health.service("foobar", options: options)[0]["Node"]["Node"]).to eq("foobar")
     end
 
+    it "service with tag options" do
+      json = <<EOF
+[
+    {
+        "Node": {
+            "Node": "foobar",
+            "Address": "10.1.10.12"
+        },
+        "Service": {
+            "ID": "redis",
+            "Service": "redis",
+            "Tags": ["v1"],
+            "Port": 8000
+        },
+        "Checks": [
+            {
+                "Node": "foobar",
+                "CheckID": "service:redis",
+                "Name": "Service 'redis' check",
+                "Status": "passing",
+                "Notes": "",
+                "Output": "",
+                "ServiceID": "redis",
+                "ServiceName": "redis"
+            },
+            {
+                "Node": "foobar",
+                "CheckID": "serfHealth",
+                "Name": "Serf Health Status",
+                "Status": "passing",
+                "Notes": "",
+                "Output": "",
+                "ServiceID": "",
+                "ServiceName": ""
+            }
+        ]
+    }
+]
+EOF
+
+      faraday.stub(:get).and_return(OpenStruct.new({ body: json }))
+
+      health = Diplomat::Health.new(faraday)
+
+      options = { tag: 'v1' }
+
+      expect(health.service("foobar", options: options)[0]["Node"]["Node"]).to eq("foobar")
+    end
+
     it "state" do
       json = <<EOF
 [

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -118,16 +118,20 @@ describe Diplomat::Node do
     end
 
     describe "GET" do
-      it "gets a node" do
+      let(:cn) do
         json = JSON.generate(body)
-
         Diplomat.configuration.acl_token = nil
         faraday.stub(:get).with(key_url).and_return(OpenStruct.new({ body: json }))
-
         node = Diplomat::Node.new(faraday)
+        node.get("foobar")
+      end
 
-        cn = node.get("foobar")
+      it "gets a node" do
         expect(cn["Node"].length).to eq(2)
+      end
+
+      it "returns an OpenStruct" do
+        expect(cn).to be_a_kind_of(OpenStruct)
       end
     end
   end

--- a/spec/prepared_query_spec.rb
+++ b/spec/prepared_query_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+require 'json'
+
+describe Diplomat::PreparedQuery do
+
+  let(:faraday) { fake }
+
+  context "pqueries" do
+    let(:key_url) { "/v1/query" }
+
+    let(:id) { "8f246b77-f3e1-ff88-5b48-8ec93abf3e05" }
+
+    let(:info_body) {
+      [
+        {
+          "ID" => id,
+          "Name" => "",
+          "Template" => {
+            "Type" => "name_prefix_match"
+          },
+          "Service" => {
+            "Service" => "${name.full}",
+            "Failover" => {
+              "NearestN" => 3
+            },
+          }
+        }
+      ]
+    }
+    let(:list_body) {
+      [
+        info_body.first,
+        {
+          "ID" => "7f62f110-30b1-b29d-c693-e3ec2c9e8e37",
+          "Name" => "my-query",
+          "Token" => "",
+          "Service" => {
+            "Service" => "redis",
+            "Failover" => {
+              "NearestN" => 3,
+              "Datacenters" => ["dc1", "dc2"]
+            },
+            "Near" => "node1",
+            "OnlyPassing" => false,
+            "Tags" => ["primary", "!experimental"]
+          },
+          "DNS" => {
+            "TTL" => "10s"
+          }
+        }
+      ]
+    }
+
+    describe "info" do
+      it "returns existing prepared query" do
+        json = JSON.generate(info_body)
+
+        url = key_url
+        expect(faraday).to receive(:get).with(/#{url}/).and_return(OpenStruct.new({ body: json, status: 200}))
+
+        pquery = Diplomat::PreparedQuery.new(faraday)
+        info = pquery.info('')
+
+        expect(info["Name"]).to eq("")
+      end
+
+      it "returns does not return prepared query" do
+        json = '[]'
+
+        url = key_url
+        expect(faraday).to receive(:get).with(/#{url}/).and_return(OpenStruct.new({ body: json, status: 200}))
+
+        pquery = Diplomat::PreparedQuery.new(faraday)
+
+        expect { pquery.info('none') }.to raise_error(Diplomat::PreparedQueryNotFound)
+      end
+    end
+
+    describe "list" do
+      it "return all prepared queries" do
+        json = JSON.generate(list_body)
+
+        url = key_url
+        expect(faraday).to receive(:get).with(/#{url}/).and_return(OpenStruct.new({ body: json, status: 200}))
+
+        pquery = Diplomat::PreparedQuery.new(faraday)
+        list = pquery.list
+
+        expect(list.size).to eq(2)
+      end
+    end
+
+    describe "update" do
+      it "return status" do
+        json = JSON.generate(list_body)
+
+        url = key_url
+        req = fake
+        expect(faraday).to receive(:get).with(/#{url}/).and_return(OpenStruct.new({ body: json, status: 200}))
+        expect(faraday).to receive(:put).and_yield(req).and_return(OpenStruct.new({ status: 200}))
+        expect(req).to receive(:url).with(/#{url}\/#{id}/)
+
+        pquery = Diplomat::PreparedQuery.new(faraday)
+        response = pquery.update("", json)
+
+        expect(response).to be true
+      end
+    end
+
+    describe "create" do
+      it "returns an ID" do
+        json = JSON.generate(info_body.reject{|key, _| key == 'ID'}) # Delete the ID key, not authorized in create calls
+
+        url = key_url
+        req = fake
+        expect(faraday).to receive(:post).and_yield(req).and_return(OpenStruct.new({ body: "{ \"ID\":\"#{id}\" }", status: 200}))
+        expect(req).to receive(:url).with(/#{url}/)
+
+        pquery = Diplomat::PreparedQuery.new(faraday)
+        response = pquery.create(json)
+
+        expect(response['ID']).to eq(id)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
* Using `name` as the primary key since you cannot create a prepared query by specifying its ID (like what's do-able for ACLs)
* Rebased on upstream